### PR TITLE
Update Python dependencies

### DIFF
--- a/create_people_posters/requirements-colorize.txt
+++ b/create_people_posters/requirements-colorize.txt
@@ -1,14 +1,14 @@
 # CPU PyTorch (works cross-platform; no GPU/CUDA required)
 --extra-index-url https://download.pytorch.org/whl/cpu
-torch==1.13.1+cpu
-torchvision==0.14.1+cpu
+torch==2.13.0
+torchvision==0.28.0
 
 # pkg_resources is provided by setuptools; some Python/venv builds no longer include it by default
-setuptools>=65,<81
+setuptools==83.0.0
 wheel
 
 # DeOldify stack
-fastai==1.0.61
+fastai==2.8.7
 
 # Runtime deps (image I/O & DeOldify imports)
 Pillow>=10.0.0
@@ -20,8 +20,8 @@ imageio>=2.34.0
 imageio-ffmpeg>=0.4.9
 
 # IMPORTANT: fastai 1.x ecosystem expects NumPy 1.x
-numpy<2
-numexpr<2.9
+numpy==2.5.1
+numexpr==2.14.2
 
-ipython<9
-matplotlib<3.9
+ipython==9.15.0
+matplotlib==3.11.1


### PR DESCRIPTION
## Summary

Updates outdated pinned Python dependencies to their latest stable PyPI releases.

Target branch: `main`

Unpinned dependencies, direct URL dependencies, Git dependencies and path dependencies were not changed.

## Changes

| File | Package | Previous | Updated |
|---|---|---|---|
| [`create_people_posters/requirements-colorize.txt`](https://github.com/Kometa-Team/Defaults-Image-Creation/blob/main/create_people_posters/requirements-colorize.txt) | `torch` | `torch==1.13.1+cpu` | `torch==2.13.0` |
| [`create_people_posters/requirements-colorize.txt`](https://github.com/Kometa-Team/Defaults-Image-Creation/blob/main/create_people_posters/requirements-colorize.txt) | `torchvision` | `torchvision==0.14.1+cpu` | `torchvision==0.28.0` |
| [`create_people_posters/requirements-colorize.txt`](https://github.com/Kometa-Team/Defaults-Image-Creation/blob/main/create_people_posters/requirements-colorize.txt) | `setuptools` | `setuptools>=65,<81` | `setuptools==83.0.0` |
| [`create_people_posters/requirements-colorize.txt`](https://github.com/Kometa-Team/Defaults-Image-Creation/blob/main/create_people_posters/requirements-colorize.txt) | `fastai` | `fastai==1.0.61` | `fastai==2.8.7` |
| [`create_people_posters/requirements-colorize.txt`](https://github.com/Kometa-Team/Defaults-Image-Creation/blob/main/create_people_posters/requirements-colorize.txt) | `numpy` | `numpy<2` | `numpy==2.5.1` |
| [`create_people_posters/requirements-colorize.txt`](https://github.com/Kometa-Team/Defaults-Image-Creation/blob/main/create_people_posters/requirements-colorize.txt) | `numexpr` | `numexpr<2.9` | `numexpr==2.14.2` |
| [`create_people_posters/requirements-colorize.txt`](https://github.com/Kometa-Team/Defaults-Image-Creation/blob/main/create_people_posters/requirements-colorize.txt) | `ipython` | `ipython<9` | `ipython==9.15.0` |
| [`create_people_posters/requirements-colorize.txt`](https://github.com/Kometa-Team/Defaults-Image-Creation/blob/main/create_people_posters/requirements-colorize.txt) | `matplotlib` | `matplotlib<3.9` | `matplotlib==3.11.1` |

---

Generated by `reposcan.py`.